### PR TITLE
Fix a typo in firebase_cloud_messenger.gemspec

### DIFF
--- a/firebase_cloud_messenger.gemspec
+++ b/firebase_cloud_messenger.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["vdevendra@patientslikeme.com"]
   spec.homepage      = "https://github.com/patientslikeme/firebase_cloud_messenger"
 
-  spec.summary       = %q{A ruby api wrapper for the FirebaseCloudMesenger API}
+  spec.summary       = %q{A wrapper for the Firebase Cloud Messaging API}
   spec.description   = spec.summary
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
Do you want the version to be increased for fixing a typo?

Feel free to also just incorporate this fix within the next PR and close this one, it is not a big thing, but it bugged me when I read it on rubygems.org 👻 

Thx for this gem! 🙂